### PR TITLE
fix memory leak on windows caused by threading

### DIFF
--- a/src/frontend/maxmsp/mc.nn_tilde/mc.nn_tilde.cpp
+++ b/src/frontend/maxmsp/mc.nn_tilde/mc.nn_tilde.cpp
@@ -186,6 +186,12 @@ mc_nn_tilde::mc_nn_tilde(const atoms &args)
     m_buffer_size = power_ceil(m_buffer_size);
   }
 
+// Calling forward in a thread causes memory leak in windows.
+// See https://github.com/pytorch/pytorch/issues/24237
+#ifdef _WIN32
+  m_use_thread = false;
+#endif
+
   // CREATE INLETS, OUTLETS and BUFFERS
   m_in_buffer = std::make_unique<circular_buffer<double, float>[]>(m_in_dim * get_batches());
   for (int i(0); i < m_in_dim; i++) {

--- a/src/frontend/maxmsp/mcs.nn_tilde/mcs.nn_tilde.cpp
+++ b/src/frontend/maxmsp/mcs.nn_tilde/mcs.nn_tilde.cpp
@@ -182,6 +182,12 @@ mc_bnn_tilde::mc_bnn_tilde(const atoms &args)
     m_buffer_size = power_ceil(m_buffer_size);
   }
 
+// Calling forward in a thread causes memory leak in windows.
+// See https://github.com/pytorch/pytorch/issues/24237
+#ifdef _WIN32
+  m_use_thread = false;
+#endif
+
   // CREATE INLETS, OUTLETS 
   std::cout << "number of batches : " << get_batches() << std::endl;
   for (int i(0); i < get_batches(); i++) {

--- a/src/frontend/maxmsp/nn_tilde/nn_tilde.cpp
+++ b/src/frontend/maxmsp/nn_tilde/nn_tilde.cpp
@@ -148,6 +148,12 @@ nn::nn(const atoms &args)
     m_buffer_size = power_ceil(m_buffer_size);
   }
 
+  // Calling forward in a thread causes memory leak in windows.
+  // See https://github.com/pytorch/pytorch/issues/24237
+#ifdef _WIN32
+  m_use_thread = false;
+#endif
+
   // CREATE INLETS, OUTLETS and BUFFERS
   m_in_buffer = std::make_unique<circular_buffer<double, float>[]>(m_in_dim);
   for (int i(0); i < m_in_dim; i++) {


### PR DESCRIPTION
This fixes issue #24, this is a bug in pytorch where CPU inference on windows results in constantly increasing memory usage when threads are called. See https://github.com/pytorch/pytorch/issues/24237 and https://github.com/pytorch/pytorch/issues/24237 and disabling threading makes the problem go away.