### PR TITLE
Add interleave support for circular buffers.

### DIFF
--- a/src/frontend/maxmsp/shared/circular_buffer.h
+++ b/src/frontend/maxmsp/shared/circular_buffer.h
@@ -89,6 +89,7 @@ void circular_buffer<in_type, out_type>::get(out_type *output_array, int N) {
   }
 }
 
+// get to an interleaved format
 template <class in_type, class out_type>
 void circular_buffer<in_type, out_type>::get_interleave(out_type* output_array, int channels, int N) {
     if (!_max_size)
@@ -99,7 +100,8 @@ void circular_buffer<in_type, out_type>::get_interleave(out_type* output_array, 
             *(output_array++) = out_type();
         }
         else {
-            *(output_array++) = _buffer[_tail];
+            *(output_array) = _buffer[_tail];
+
             _tail = (_tail + 1) % _max_size;
             _full = false;
         }

--- a/src/frontend/maxmsp/shared/circular_buffer.h
+++ b/src/frontend/maxmsp/shared/circular_buffer.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <memory>
-#include <stdio.h>
 
 template <class in_type, class out_type> class circular_buffer {
 public:


### PR DESCRIPTION
Hello!

I've been working on porting nn~ to ChucK, which embeds multi-channel in an interleave format. To get the circular buffer to work with that, I added the put_interleave and get_interleave methods. I figured it might be useful to someone else, so I'm pushing the changes upstream.