### PR TITLE
minor fix for compiling on win 10

### DIFF
--- a/src/frontend/maxmsp/nn_tilde/nn_tilde.cpp
+++ b/src/frontend/maxmsp/nn_tilde/nn_tilde.cpp
@@ -83,9 +83,8 @@ public:
     MIN_FUNCTION {
       symbol attribute_name = args[0];
       if (attribute_name == "get_attributes") {
-        for (std::string attr : settable_attributes) {
+        for (std::string attr : settable_attributes)
           cout << attr << endl;
-        }
         return {};
       } 
       else if (attribute_name == "get_methods") 


### PR DESCRIPTION
`nn_tilde.cpp` wouldn't compile for me until I did this minor edit... i have no idea why. But this way, the syntax is identical to [mc.tilde~](https://github.com/acids-ircam/nn_tilde/blob/master/src/frontend/maxmsp/mc.nn_tilde/mc.nn_tilde.cpp#L100) and `mcs.tilde~`.