### PR TITLE
Moved set attribute to a FIFO to stop threading related crashes

### DIFF
--- a/src/frontend/maxmsp/mc.nn_tilde/mc.nn_tilde.cpp
+++ b/src/frontend/maxmsp/mc.nn_tilde/mc.nn_tilde.cpp
@@ -157,10 +157,10 @@ int mc_nn_tilde::get_batches() {
 void model_perform(mc_nn_tilde *mc_nn_instance) {
   // set attributes
   std::vector<std::string> attribute_name_and_args;
-	while (nn_instance->set_attribute_queue.try_dequeue(attribute_name_and_args)) {
+	while (mc_nn_instance->set_attribute_queue.try_dequeue(attribute_name_and_args)) {
     std::vector<std::string> attribute_args(attribute_name_and_args.begin() + 1, attribute_name_and_args.end());
 		try {
-      nn_instance->m_model.set_attribute(attribute_name_and_args[0], attribute_args);
+      mc_nn_instance->m_model.set_attribute(attribute_name_and_args[0], attribute_args);
     } catch (std::string message) {
       std::cerr << message << std::endl;
     }

--- a/src/frontend/maxmsp/mc.nn_tilde/mc.nn_tilde.cpp
+++ b/src/frontend/maxmsp/mc.nn_tilde/mc.nn_tilde.cpp
@@ -48,6 +48,7 @@ public:
   bool has_settable_attribute(std::string attribute);
   c74::min::path m_path;
   int m_in_dim, m_in_ratio, m_out_dim, m_out_ratio, m_higher_ratio;
+	fifo<std::vector<std::string>>	set_attribute_queue { 100 };
 
   // BUFFER RELATED MEMBERS
   int m_buffer_size;
@@ -130,14 +131,11 @@ public:
         attribute_name = args[1];
         std::vector<std::string> attribute_args;
         if (has_settable_attribute(attribute_name)) {
-          for (int i = 2; i < args.size(); i++) {
+          for (int i = 1; i < args.size(); i++) {
             attribute_args.push_back(args[i]);
           }
-          try {
-            m_model.set_attribute(attribute_name, attribute_args);
-          } catch (std::string message) {
-            cerr << message << endl;
-          }
+          
+          set_attribute_queue.try_enqueue(attribute_args);
         } else {
           cerr << "model does not have attribute " << attribute_name << endl;
         }
@@ -157,6 +155,17 @@ int mc_nn_tilde::get_batches() {
 
 
 void model_perform(mc_nn_tilde *mc_nn_instance) {
+  // set attributes
+  std::vector<std::string> attribute_name_and_args;
+	while (nn_instance->set_attribute_queue.try_dequeue(attribute_name_and_args)) {
+    std::vector<std::string> attribute_args(attribute_name_and_args.begin() + 1, attribute_name_and_args.end());
+		try {
+      nn_instance->m_model.set_attribute(attribute_name_and_args[0], attribute_args);
+    } catch (std::string message) {
+      std::cerr << message << std::endl;
+    }
+	}
+
   std::vector<float *> in_model, out_model;
 
   for (int c(0); c < mc_nn_instance->m_in_dim; c++)

--- a/src/frontend/maxmsp/mcs.nn_tilde/mcs.nn_tilde.cpp
+++ b/src/frontend/maxmsp/mcs.nn_tilde/mcs.nn_tilde.cpp
@@ -161,10 +161,10 @@ int mc_bnn_tilde::get_batches() {
 void model_perform(mc_bnn_tilde *mc_nn_instance) {
   // set attributes
   std::vector<std::string> attribute_name_and_args;
-	while (nn_instance->set_attribute_queue.try_dequeue(attribute_name_and_args)) {
+	while (mc_nn_instance->set_attribute_queue.try_dequeue(attribute_name_and_args)) {
     std::vector<std::string> attribute_args(attribute_name_and_args.begin() + 1, attribute_name_and_args.end());
 		try {
-      nn_instance->m_model.set_attribute(attribute_name_and_args[0], attribute_args);
+      mc_nn_instance->m_model.set_attribute(attribute_name_and_args[0], attribute_args);
     } catch (std::string message) {
       std::cerr << message << std::endl;
     }

--- a/src/frontend/maxmsp/nn_tilde/nn_tilde.cpp
+++ b/src/frontend/maxmsp/nn_tilde/nn_tilde.cpp
@@ -41,6 +41,7 @@ public:
   bool has_settable_attribute(std::string attribute);
   c74::min::path m_path;
   int m_in_dim, m_in_ratio, m_out_dim, m_out_ratio, m_higher_ratio;
+	fifo<std::vector<std::string>>	set_attribute_queue { 100 };
 
   // BUFFER RELATED MEMBERS
   int m_buffer_size;
@@ -117,14 +118,11 @@ public:
         attribute_name = args[1];
         std::vector<std::string> attribute_args;
         if (has_settable_attribute(attribute_name)) {
-          for (int i = 2; i < args.size(); i++) {
+          for (int i = 1; i < args.size(); i++) {
             attribute_args.push_back(args[i]);
           }
-          try {
-            m_model.set_attribute(attribute_name, attribute_args);
-          } catch (std::string message) {
-            cerr << message << endl;
-          }
+          
+          set_attribute_queue.try_enqueue(attribute_args);
         } else {
           cerr << "model does not have attribute " << attribute_name << endl;
         }
@@ -138,6 +136,17 @@ public:
 };
 
 void model_perform(nn *nn_instance) {
+  // set attributes
+  std::vector<std::string> attribute_name_and_args;
+	while (nn_instance->set_attribute_queue.try_dequeue(attribute_name_and_args)) {
+    std::vector<std::string> attribute_args(attribute_name_and_args.begin() + 1, attribute_name_and_args.end());
+		try {
+      nn_instance->m_model.set_attribute(attribute_name_and_args[0], attribute_args);
+    } catch (std::string message) {
+      std::cerr << message << std::endl;
+    }
+	}
+
   std::vector<float *> in_model, out_model;
   for (int c(0); c < nn_instance->m_in_dim; c++)
     in_model.push_back(nn_instance->m_in_model[c].get());


### PR DESCRIPTION
When setting attributes occasionally it would crash because the messages are running on different threads. I added a FIFO to stop this from happening.